### PR TITLE
[FEAT] 챗봇 추천 상품 조회 API 구현

### DIFF
--- a/src/main/java/com/refit/app/domain/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/refit/app/domain/chatbot/controller/ChatbotController.java
@@ -1,0 +1,22 @@
+package com.refit.app.domain.chatbot.controller;
+
+import com.refit.app.domain.chatbot.dto.request.ProductSearchRequest;
+import com.refit.app.domain.chatbot.dto.response.ProductSearchListResponse;
+import com.refit.app.domain.chatbot.service.ChatbotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chatbot")
+@RequiredArgsConstructor
+public class ChatbotController {
+
+    private final ChatbotService chatbotService;
+
+    @PostMapping("/products")
+    public ResponseEntity<ProductSearchListResponse> searchProducts(@RequestBody ProductSearchRequest request) {
+        return ResponseEntity.ok(chatbotService.searchProducts(request));
+    }
+}
+

--- a/src/main/java/com/refit/app/domain/chatbot/dto/ProductCursorDto.java
+++ b/src/main/java/com/refit/app/domain/chatbot/dto/ProductCursorDto.java
@@ -1,0 +1,18 @@
+package com.refit.app.domain.chatbot.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductCursorDto {
+    private Long productId;
+    private Long sales;
+    private Long discountedPrice;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/refit/app/domain/chatbot/dto/ProductSearchRequestDto.java
+++ b/src/main/java/com/refit/app/domain/chatbot/dto/ProductSearchRequestDto.java
@@ -1,0 +1,27 @@
+package com.refit.app.domain.chatbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchRequestDto {
+    private Integer bhType;       // 뷰티/헬스 구분
+    private List<Long> effectIds; // 효능 ID 배열
+    private String sort;          // latest, popular, lowPrice, highPrice
+    private Long lastId;          // 커서 ID
+    private Integer limit;        // 조회 개수
+
+    // 커서 비교용 필드 (lastId 상품의 값)
+    private LocalDateTime cursorCreatedAt;
+    private Long cursorSales;
+    private Long cursorDiscountedPrice;
+    private Integer effectCount;
+}

--- a/src/main/java/com/refit/app/domain/chatbot/dto/ProductSearchResponseDto.java
+++ b/src/main/java/com/refit/app/domain/chatbot/dto/ProductSearchResponseDto.java
@@ -1,0 +1,21 @@
+package com.refit.app.domain.chatbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchResponseDto {
+    private Long productId;
+    private String thumbnailUrl;
+    private String brandName;
+    private String productName;
+    private Long discountRate;
+    private Long originalPrice;
+    private Long discountedPrice;
+    private Long sales;
+}

--- a/src/main/java/com/refit/app/domain/chatbot/dto/request/ProductSearchRequest.java
+++ b/src/main/java/com/refit/app/domain/chatbot/dto/request/ProductSearchRequest.java
@@ -1,0 +1,20 @@
+package com.refit.app.domain.chatbot.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchRequest {
+    private Integer bhType;       // 뷰티/헬스 구분
+    private List<Long> effectIds; // 효능 ID 배열
+    private String sort;          // latest, popular, lowPrice, highPrice
+    private Long lastId;          // 커서 ID
+    private Integer limit;        // 조회 개수
+}

--- a/src/main/java/com/refit/app/domain/chatbot/dto/response/ProductSearchListResponse.java
+++ b/src/main/java/com/refit/app/domain/chatbot/dto/response/ProductSearchListResponse.java
@@ -1,0 +1,17 @@
+package com.refit.app.domain.chatbot.dto.response;
+
+import com.refit.app.domain.chatbot.dto.ProductSearchResponseDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchListResponse {
+    private List<ProductSearchResponseDto> items;
+    private Long totalCount;
+}

--- a/src/main/java/com/refit/app/domain/chatbot/mapper/ChatbotMapper.java
+++ b/src/main/java/com/refit/app/domain/chatbot/mapper/ChatbotMapper.java
@@ -1,0 +1,15 @@
+package com.refit.app.domain.chatbot.mapper;
+
+import com.refit.app.domain.chatbot.dto.ProductCursorDto;
+import com.refit.app.domain.chatbot.dto.ProductSearchRequestDto;
+import com.refit.app.domain.chatbot.dto.ProductSearchResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ChatbotMapper {
+    ProductCursorDto findCursorInfo(Long productId);
+    List<ProductSearchResponseDto> searchProducts(ProductSearchRequestDto request);
+    Long countProducts(ProductSearchRequestDto request);
+}

--- a/src/main/java/com/refit/app/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/refit/app/domain/chatbot/service/ChatbotService.java
@@ -1,0 +1,8 @@
+package com.refit.app.domain.chatbot.service;
+
+import com.refit.app.domain.chatbot.dto.request.ProductSearchRequest;
+import com.refit.app.domain.chatbot.dto.response.ProductSearchListResponse;
+
+public interface ChatbotService {
+    ProductSearchListResponse searchProducts(ProductSearchRequest request);
+}

--- a/src/main/java/com/refit/app/domain/chatbot/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/refit/app/domain/chatbot/service/ChatbotServiceImpl.java
@@ -1,0 +1,61 @@
+package com.refit.app.domain.chatbot.service;
+
+import com.refit.app.domain.chatbot.dto.ProductCursorDto;
+import com.refit.app.domain.chatbot.dto.ProductSearchRequestDto;
+import com.refit.app.domain.chatbot.dto.ProductSearchResponseDto;
+import com.refit.app.domain.chatbot.dto.request.ProductSearchRequest;
+import com.refit.app.domain.chatbot.dto.response.ProductSearchListResponse;
+import com.refit.app.domain.chatbot.mapper.ChatbotMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatbotServiceImpl implements ChatbotService {
+
+    private final ChatbotMapper chatbotMapper;
+
+    @Override
+    public ProductSearchListResponse searchProducts(ProductSearchRequest request) {
+
+        ProductCursorDto cursorInfo = null;
+
+        // lastId가 있을 때만 커서 정보 조회
+        if (request.getLastId() != null) {
+            cursorInfo = chatbotMapper.findCursorInfo(request.getLastId());
+            if (cursorInfo == null) throw new RuntimeException("유효하지 않은 lastId");
+        }
+
+        ProductSearchRequestDto req = ProductSearchRequestDto.builder()
+                .bhType(request.getBhType())
+                .effectIds(request.getEffectIds())
+                .sort(request.getSort())
+                .lastId(request.getLastId())
+                .limit(request.getLimit())
+                .cursorCreatedAt(cursorInfo != null ? cursorInfo.getCreatedAt() : null)
+                .cursorSales(cursorInfo != null ? cursorInfo.getSales() : null)
+                .cursorDiscountedPrice(cursorInfo != null ? cursorInfo.getDiscountedPrice() : null)
+                .effectCount(request.getEffectIds() != null ? request.getEffectIds().size() : null)
+                .build();
+
+        // 상품 리스트 조회
+        List<ProductSearchResponseDto> items = chatbotMapper.searchProducts(req);
+
+        // 할인 가격 계산
+        items.forEach(item -> {
+            long discounted = (item.getOriginalPrice() * (100 - item.getDiscountRate())) / 100;
+            discounted = (discounted / 100) * 100; // 100원 단위 절삭
+            item.setDiscountedPrice(discounted);
+        });
+
+        Long totalCount = chatbotMapper.countProducts(req);
+
+        return ProductSearchListResponse.builder()
+                .items(items)
+                .totalCount(totalCount)
+                .build();
+    }
+
+}

--- a/src/main/resources/mapper/chatbot/ChatbotMapper.xml
+++ b/src/main/resources/mapper/chatbot/ChatbotMapper.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.refit.app.domain.chatbot.mapper.ChatbotMapper">
+
+    <!-- 커서값 찾기 -->
+    <select id="findCursorInfo" parameterType="long"
+            resultType="com.refit.app.domain.chatbot.dto.ProductCursorDto">
+        SELECT
+            p.PRODUCT_ID       AS productId,
+            NVL(SUM(oi.ITEM_COUNT - oi.CANCELED_COUNT), 0) AS sales,
+            p.CREATED_AT       AS createdAt,
+            (FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) AS discountedPrice
+        FROM PRODUCT p
+                 LEFT JOIN ORDER_ITEM oi ON p.PRODUCT_ID = oi.PRODUCT_ID
+        WHERE p.PRODUCT_ID = #{productId}
+        GROUP BY p.PRODUCT_ID, p.PRICE, p.DISCOUNT_RATE, p.CREATED_AT
+    </select>
+
+
+    <!-- 상품 검색 -->
+    <select id="searchProducts" parameterType="com.refit.app.domain.chatbot.dto.ProductSearchRequestDto"
+            resultType="com.refit.app.domain.chatbot.dto.ProductSearchResponseDto">
+
+        SELECT
+        p.PRODUCT_ID       AS productId,
+        p.THUMBNAIL_URL    AS thumbnailUrl,
+        p.BRAND_NAME       AS brandName,
+        p.PRODUCT_NAME     AS productName,
+        p.DISCOUNT_RATE    AS discountRate,
+        p.PRICE            AS originalPrice,
+        NVL(SUM(oi.ITEM_COUNT - oi.CANCELED_COUNT), 0) AS sales,
+        p.CREATED_AT       AS createdAt
+        FROM PRODUCT p
+        LEFT JOIN PRODUCT_EFFECT pe ON p.PRODUCT_ID = pe.PRODUCT_ID
+        LEFT JOIN ORDER_ITEM oi ON p.PRODUCT_ID = oi.PRODUCT_ID
+        WHERE p.BH_TYPE = #{bhType}
+        AND p.DELETED_AT IS NULL
+        <if test="effectIds != null and !effectIds.isEmpty()">
+        AND pe.EFFECT_ID IN
+            <foreach item="id" collection="effectIds" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </if>
+
+        GROUP BY p.PRODUCT_ID,
+        p.THUMBNAIL_URL,
+        p.BRAND_NAME,
+        p.PRODUCT_NAME,
+        p.DISCOUNT_RATE,
+        p.PRICE,
+        p.CREATED_AT
+
+        <if test="effectCount != null and effectCount > 0">
+            HAVING COUNT(DISTINCT pe.EFFECT_ID) = #{effectCount}
+        </if>
+
+        <choose>
+            <!-- 최신순 -->
+            <when test="sort == 'latest'">
+                <if test="lastId != null and cursorCreatedAt != null">
+                    AND (p.CREATED_AT &lt; #{cursorCreatedAt}
+                    OR (p.CREATED_AT = #{cursorCreatedAt} AND p.PRODUCT_ID &lt; #{lastId}))
+                </if>
+                ORDER BY p.CREATED_AT DESC, p.PRODUCT_ID DESC
+            </when>
+
+            <!-- 인기순 -->
+            <when test="sort == 'popular'">
+                <if test="lastId != null and cursorSales != null">
+                    AND (NVL(SUM(oi.ITEM_COUNT - oi.CANCELED_COUNT),0) &lt; #{cursorSales}
+                    OR (NVL(SUM(oi.ITEM_COUNT - oi.CANCELED_COUNT),0) = #{cursorSales} AND p.PRODUCT_ID &lt; #{lastId}))
+                </if>
+                ORDER BY sales DESC, p.PRODUCT_ID DESC
+            </when>
+
+            <!-- 가격 오름차순 -->
+            <when test="sort == 'lowPrice'">
+                <if test="lastId != null and cursorDiscountedPrice != null">
+                    AND ((FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) &gt; #{cursorDiscountedPrice}
+                    OR ((FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) = #{cursorDiscountedPrice} AND p.PRODUCT_ID &gt; #{lastId}))
+                </if>
+                ORDER BY (FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) ASC, p.PRODUCT_ID ASC
+            </when>
+
+            <!-- 가격 내림차순 -->
+            <when test="sort == 'highPrice'">
+                <if test="lastId != null and cursorDiscountedPrice != null">
+                    AND ((FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) &lt; #{cursorDiscountedPrice}
+                    OR ((FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) = #{cursorDiscountedPrice} AND p.PRODUCT_ID &lt; #{lastId}))
+                </if>
+                ORDER BY (FLOOR((p.PRICE * (100 - p.DISCOUNT_RATE)) / 100) * 100) DESC, p.PRODUCT_ID DESC
+            </when>
+
+            <!-- 기본: 최신순 -->
+            <otherwise>
+                ORDER BY p.CREATED_AT DESC, p.PRODUCT_ID DESC
+            </otherwise>
+        </choose>
+
+        FETCH FIRST #{limit} ROWS ONLY
+    </select>
+
+    <!-- 총 개수 조회 -->
+    <select id="countProducts" parameterType="com.refit.app.domain.chatbot.dto.ProductSearchRequestDto"
+            resultType="long">
+        SELECT COUNT(*)
+        FROM (
+        SELECT p.PRODUCT_ID
+        FROM PRODUCT p
+        LEFT JOIN PRODUCT_EFFECT pe ON p.PRODUCT_ID = pe.PRODUCT_ID
+        WHERE p.BH_TYPE = #{bhType}
+        AND p.DELETED_AT IS NULL
+        <if test="effectIds != null and !effectIds.isEmpty()">
+        AND pe.EFFECT_ID IN
+            <foreach item="id" collection="effectIds" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </if>
+        GROUP BY p.PRODUCT_ID
+        <if test="effectCount != null and effectCount > 0">
+            HAVING COUNT(DISTINCT pe.EFFECT_ID) = #{effectCount}
+        </if>
+        ) sub
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣ Issue Number
#76 

## 📝 요약(Summary)

POST며 url은 /chatbot/products 입니다.
{
  "bhType": 1,
  "effectIds": [11, 12],
  "sort": "popular",
  "lastId": 100,
  "limit": 20
}

처럼 보내시면 되고 effectIds란 효능번호

EFFECT_ID | EFFECT_NAME 
16 | 뼈 건강 
17 | 활력
18 | 피부 건강
0 | 보습
1 | 진정 
2 | 주름 개선
3 | 미백 
4 | 자외선 차단 
5 | 여드름 완화
6 | 가려움 개선 
7 | 튼살 개선 
8 | 손상모 개선
9 | 탈모 개선 
10 | 두피 개선 
11 | 혈행 개선
12 | 장 건강
13 | 면역력 증진 
14 | 항산화 
15 | 눈 건강 

에 해당하는 번호입니다. (nullable입니다.)

sort로는 "latest", "popular", "lowPrice", "highPrice" 를 받을 수 있습니다.

자세한 명세서는 노션에 작성해놨습니다.
https://www.notion.so/261e725a872580c38d0ef8722eb37c2a?source=copy_link

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

