### PR TITLE
[FEAT] 푸시알림 개선 및 결제/소비기한 만료 이벤트 알림 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ dependencies {
     implementation 'org.springframework:spring-messaging'
 
     implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+
+    // shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.15.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.15.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/refit/app/domain/memberProduct/dto/ExpiryCandidate.java
+++ b/src/main/java/com/refit/app/domain/memberProduct/dto/ExpiryCandidate.java
@@ -1,0 +1,14 @@
+package com.refit.app.domain.memberProduct.dto;
+
+import lombok.Data;
+import java.time.LocalDate;
+
+@Data
+public class ExpiryCandidate {
+    private Long memberProductId;
+    private Long memberId;
+    private Long productId;
+    private String productName;
+    private String brandName;
+    private LocalDate expiryDate;
+}

--- a/src/main/java/com/refit/app/domain/memberProduct/mapper/MemberProductMapper.java
+++ b/src/main/java/com/refit/app/domain/memberProduct/mapper/MemberProductMapper.java
@@ -1,5 +1,6 @@
 package com.refit.app.domain.memberProduct.mapper;
 
+import com.refit.app.domain.memberProduct.dto.ExpiryCandidate;
 import com.refit.app.domain.memberProduct.dto.MetaRow;
 import com.refit.app.domain.memberProduct.dto.ProductSimpleRow;
 import com.refit.app.domain.memberProduct.dto.response.MemberProductDetailResponse;
@@ -105,4 +106,9 @@ public interface MemberProductMapper {
     List<Map<String,Object>> selectSkinCompat(@Param("ids") List<Long> ids,
             @Param("skinType") Integer skinType);
 
+    // 7일 전 대상자 조회
+    List<ExpiryCandidate> selectExpiryIn7Days();
+
+    // 알림 발송 후 플래그 업데이트
+    int markExpiry7Sent(@Param("memberProductId") Long memberProductId);
 }

--- a/src/main/java/com/refit/app/domain/notification/mapper/DeviceMapper.java
+++ b/src/main/java/com/refit/app/domain/notification/mapper/DeviceMapper.java
@@ -15,6 +15,12 @@ public interface DeviceMapper {
     int deleteDeviceByDeviceId(@Param("memberId") Long memberId,
             @Param("deviceId") String deviceId);
 
-    List<String> selectTokensByMemberId(@Param("memberId") Long memberId);
+    List<String> selectActiveTokensByMemberId(@Param("memberId") Long memberId);
 
+    void deactivateByToken(@Param("token") String token);
+
+    void markSuccessByToken(@Param("token") String token);
+
+    // 오래된 비활성 토큰 정리
+    int deleteStale();
 }

--- a/src/main/java/com/refit/app/domain/notification/scheduler/ExpiryImminentScheduler.java
+++ b/src/main/java/com/refit/app/domain/notification/scheduler/ExpiryImminentScheduler.java
@@ -1,0 +1,45 @@
+package com.refit.app.domain.notification.scheduler;
+
+import com.refit.app.domain.memberProduct.dto.ExpiryCandidate;
+import com.refit.app.domain.memberProduct.mapper.MemberProductMapper;
+import com.refit.app.domain.notification.service.NotificationTriggerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExpiryImminentScheduler {
+
+    private final MemberProductMapper memberProductMapper;
+    private final NotificationTriggerService notificationTriggerService;
+
+
+    // 매일 09:30 KST 실행
+    @Scheduled(cron = "0 30 9 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "expiry-imminent-7days-job", lockAtMostFor = "PT5M", lockAtLeastFor = "PT30S")
+    @Transactional
+    public void pushForExpiryIn7Days() {
+        List<ExpiryCandidate> targets = memberProductMapper.selectExpiryIn7Days();
+        log.info("[D-7] candidates={}", targets.size());
+
+        for (ExpiryCandidate it : targets) {
+            String body = String.format("'%s'의 소비기한이 7일 이하 남았습니다.", it.getProductName());
+            try {
+                notificationTriggerService.notifyExpiryImminent(it.getMemberId(), it.getMemberProductId(), body);
+                memberProductMapper.markExpiry7Sent(it.getMemberProductId()); // 중복발송 방지 플래그
+            } catch (Exception e) {
+                log.warn("D-7 push failed mpId={}, memberId={}, err={}",
+                        it.getMemberProductId(), it.getMemberId(), e.toString());
+                // 실패 시 플래그 미변경 → 다음 실행 때 재시도
+            }
+        }
+    }
+}

--- a/src/main/java/com/refit/app/domain/notification/service/DeviceServiceImpl.java
+++ b/src/main/java/com/refit/app/domain/notification/service/DeviceServiceImpl.java
@@ -26,6 +26,6 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     public List<String> findFcmTokensByMemberId(Long memberId) {
-        return deviceMapper.selectTokensByMemberId(memberId);
+        return deviceMapper.selectActiveTokensByMemberId(memberId);
     }
 }

--- a/src/main/java/com/refit/app/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/refit/app/domain/notification/service/NotificationServiceImpl.java
@@ -3,6 +3,7 @@ package com.refit.app.domain.notification.service;
 import com.refit.app.domain.notification.dto.NotificationRowDto;
 import com.refit.app.domain.notification.dto.response.NotificationListResponse;
 import com.refit.app.domain.notification.mapper.NotificationMapper;
+import com.refit.app.domain.notification.model.NotificationType;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationMapper notificationMapper;
-    private final PushService pushService;
+    private final NotificationTriggerService notificationTriggerService;
 
     @Override
     @Transactional
@@ -47,14 +48,7 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @Transactional
     public void sendAndSave(Long memberId, String title, String body, String type, String imageUrl, String deeplink) {
-
-        notificationMapper.insertNotification(null, memberId, title, body, imageUrl, deeplink, type);
-        pushService.sendToMember(memberId, Map.of(
-                "type", type,
-                "title", title,
-                "body", body,
-                "deeplink", deeplink == null ? "" : deeplink
-        ));
+        notificationTriggerService.saveAndPush(memberId, title, body, imageUrl, deeplink, type);
     }
 }
 

--- a/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerService.java
+++ b/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerService.java
@@ -7,4 +7,6 @@ public interface NotificationTriggerService {
     void notifyPaymentCanceled(Long memberId, Long orderId, String body);
 
     void notifyExpiryImminent(Long memberId, Long productId, String body);
+
+    void saveAndPush(Long memberId, String title, String body, String imageUrl, String deeplink, String type);
 }

--- a/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerServiceImpl.java
+++ b/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerServiceImpl.java
@@ -35,7 +35,7 @@ public class NotificationTriggerServiceImpl implements NotificationTriggerServic
 
     @Override
     @Transactional
-    public void notifyExpiryImminent(Long memberId, Long productId, String body) {
+    public void notifyExpiryImminent(Long memberId, Long memberProductId, String body) {
         // 마이핏 목록으로 이동
         String deeplink = "app://myfit";
         saveAndPush(memberId, "소비기한 임박", body, null, deeplink, NotificationType.EXPIRY_IMMINENT.name());

--- a/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerServiceImpl.java
+++ b/src/main/java/com/refit/app/domain/notification/service/NotificationTriggerServiceImpl.java
@@ -22,14 +22,14 @@ public class NotificationTriggerServiceImpl implements NotificationTriggerServic
     @Override
     @Transactional
     public void notifyPaymentCompleted(Long memberId, Long orderId, String body) {
-        String deeplink = "app://orders/" + orderId;
+        String deeplink = "app://orders";
         saveAndPush(memberId, "결제 완료", body, null, deeplink, NotificationType.PAYMENT_COMPLETED.name());
     }
 
     @Override
     @Transactional
     public void notifyPaymentCanceled(Long memberId, Long orderId, String body) {
-        String deeplink = "app://orders/" + orderId;
+        String deeplink = "app://orders";
         saveAndPush(memberId, "결제 취소", body, null, deeplink, NotificationType.PAYMENT_CANCELED.name());
     }
 

--- a/src/main/java/com/refit/app/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/refit/app/domain/payment/controller/PaymentController.java
@@ -7,6 +7,7 @@ import com.refit.app.domain.payment.dto.response.PartialCancelResponse;
 import com.refit.app.domain.payment.service.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,14 +25,16 @@ public class PaymentController {
 
     // 결제 승인(앱 success 딥링크 이후)
     @PostMapping("/confirm")
-    public ConfirmPaymentResponse confirm(@RequestBody @Valid ConfirmPaymentRequest req) {
-        return service.confirm(req);
+    public ConfirmPaymentResponse confirm(@RequestBody @Valid ConfirmPaymentRequest req,
+            @AuthenticationPrincipal Long memberId) {
+        return service.confirm(req, memberId);
     }
 
     // 부분취소
     @PostMapping("/{orderItemId}/cancel")
     public PartialCancelResponse cancelByItem(@PathVariable("orderItemId") long paymentId,
-            @RequestBody @Valid PartialCancelRequest req) {
-        return service.partialCancel(paymentId, req);
+            @RequestBody @Valid PartialCancelRequest req,
+            @AuthenticationPrincipal Long memberId) {
+        return service.partialCancel(paymentId, req, memberId);
     }
 }

--- a/src/main/java/com/refit/app/domain/payment/dto/OrderRowDto.java
+++ b/src/main/java/com/refit/app/domain/payment/dto/OrderRowDto.java
@@ -13,4 +13,5 @@ public class OrderRowDto {
     private Integer orderStatus;
     private Long goodsAmount;
     private Long deliveryFee;
+    private String orderSummary;
 }

--- a/src/main/java/com/refit/app/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/refit/app/domain/payment/service/PaymentService.java
@@ -6,6 +6,6 @@ import com.refit.app.domain.payment.dto.response.ConfirmPaymentResponse;
 import com.refit.app.domain.payment.dto.response.PartialCancelResponse;
 
 public interface PaymentService {
-    ConfirmPaymentResponse confirm(ConfirmPaymentRequest req);
-    PartialCancelResponse partialCancel(Long paymentId, PartialCancelRequest req);
+    ConfirmPaymentResponse confirm(ConfirmPaymentRequest req, Long memberId);
+    PartialCancelResponse partialCancel(Long paymentId, PartialCancelRequest req, Long memberId);
 }

--- a/src/main/java/com/refit/app/global/config/SchedulingConfig.java
+++ b/src/main/java/com/refit/app/global/config/SchedulingConfig.java
@@ -1,0 +1,12 @@
+package com.refit.app.global.config;
+
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M") // 최대 10분
+public class SchedulingConfig {
+
+}

--- a/src/main/java/com/refit/app/global/config/ShedLockConfig.java
+++ b/src/main/java/com/refit/app/global/config/ShedLockConfig.java
@@ -1,0 +1,15 @@
+package com.refit.app.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+public class ShedLockConfig {
+    @Bean
+    public LockProvider lockProvider(JdbcTemplate jdbcTemplate) {
+        return new JdbcTemplateLockProvider(jdbcTemplate);
+    }
+}

--- a/src/main/resources/mapper/memberProduct/MemberProductMapper.xml
+++ b/src/main/resources/mapper/memberProduct/MemberProductMapper.xml
@@ -273,6 +273,13 @@
       <if test="startDate != null and startDate != ''">
         START_DATE = TO_DATE(#{startDate}, 'YYYY-MM-DD'),
       </if>
+      EXPIRY7_ALERT_SENT =
+          CASE
+          WHEN TRUNC(START_DATE + RECOMMENDED_EXPIRATION_DATE)
+          != TRUNC(TO_DATE(#{startDate}, 'YYYY-MM-DD') + #{recommendedPeriod})
+          THEN 0
+          ELSE EXPIRY7_ALERT_SENT
+          END,
       UPDATED_AT = SYSTIMESTAMP,
       UPDATED_BY = #{memberId}
     </set>
@@ -301,6 +308,18 @@
       <if test="startDate != null and startDate != ''">
         START_DATE = TO_DATE(#{startDate}, 'YYYY-MM-DD'),
       </if>
+
+      <!-- 만료일이 바뀌는 경우에만 플래그 리셋 -->
+      EXPIRY7_ALERT_SENT =
+          CASE
+          WHEN TRUNC(START_DATE + RECOMMENDED_EXPIRATION_DATE)
+                != TRUNC(
+                NVL(TO_DATE(#{startDate}, 'YYYY-MM-DD'), START_DATE)
+                + NVL(#{recommendedPeriod}, RECOMMENDED_EXPIRATION_DATE)
+                )
+          THEN 0
+          ELSE EXPIRY7_ALERT_SENT
+          END,
       UPDATED_AT = SYSTIMESTAMP,
       UPDATED_BY = #{memberId}
     </set>
@@ -481,6 +500,29 @@
   <select id="selectAllProductEffects" resultType="map">
     SELECT PRODUCT_ID, EFFECT_ID
     FROM PRODUCT_EFFECT
+  </select>
+
+  <update id="markExpiry7Sent">
+    UPDATE MEMBER_PRODUCT
+    SET EXPIRY7_ALERT_SENT = 1,
+        UPDATED_AT = SYSTIMESTAMP
+    WHERE MEMBER_PRODUCT_ID = #{memberProductId}
+  </update>
+
+  <select id="selectExpiryIn7Days" resultType="com.refit.app.domain.memberProduct.dto.ExpiryCandidate">
+      SELECT
+          mp.MEMBER_PRODUCT_ID     AS memberProductId,
+          mp.MEMBER_ID             AS memberId,
+          mp.PRODUCT_ID            AS productId,
+          mp.PRODUCT_NAME          AS productName,
+          mp.BRAND_NAME            AS brandName,
+          (mp.START_DATE + mp.RECOMMENDED_EXPIRATION_DATE) AS expiryDate
+      FROM MEMBER_PRODUCT mp
+      WHERE mp.USAGE_STATUS = 1
+        AND mp.DELETED_AT IS NULL
+        AND TRUNC(mp.START_DATE + mp.RECOMMENDED_EXPIRATION_DATE)
+            BETWEEN TRUNC(SYSDATE) AND TRUNC(SYSDATE) + 7
+        AND NVL(mp.EXPIRY7_ALERT_SENT, 0) = 0
   </select>
 
 </mapper>

--- a/src/main/resources/mapper/notification/DeviceMapper.xml
+++ b/src/main/resources/mapper/notification/DeviceMapper.xml
@@ -7,20 +7,25 @@
   <insert id="upsertDevice" parameterType="map">
     MERGE INTO MEMBER_DEVICE d
       USING (
-        SELECT #{memberId} AS MEMBER_ID, #{fcmToken} AS FCM_TOKEN FROM DUAL
+        SELECT #{memberId} AS MEMBER_ID,
+               #{deviceId}  AS DEVICE_ID FROM DUAL
       ) s
-      ON (d.MEMBER_ID = s.MEMBER_ID AND d.FCM_TOKEN = s.FCM_TOKEN)
+      ON (d.MEMBER_ID = s.MEMBER_ID AND d.DEVICE_ID = s.DEVICE_ID)
       WHEN MATCHED THEN UPDATE
         SET d.LAST_REFRESHED_AT = SYSTIMESTAMP,
+          d.FCM_TOKEN         = #{fcmToken},
+          d.IS_ACTIVE         = 1,
           d.UPDATED_AT = SYSTIMESTAMP,
           d.UPDATED_BY = #{memberId}
       WHEN NOT MATCHED THEN
         INSERT(
                MEMBER_DEVICE_ID, MEMBER_ID, PLATFORM, FCM_TOKEN, DEVICE_ID,
-               LAST_REFRESHED_AT, CREATED_AT, CREATED_BY, UPDATED_AT, UPDATED_BY
+               LAST_REFRESHED_AT, CREATED_AT, CREATED_BY, UPDATED_AT, UPDATED_BY,
+               IS_ACTIVE
           ) VALUES(
                     SEQ_MEMBER_DEVICE.NEXTVAL, #{memberId}, #{platform}, #{fcmToken}, #{deviceId},
-                    SYSTIMESTAMP, SYSTIMESTAMP, #{memberId}, SYSTIMESTAMP, #{memberId}
+                    SYSTIMESTAMP, SYSTIMESTAMP, #{memberId}, SYSTIMESTAMP, #{memberId},
+                    1
                   )
   </insert>
 
@@ -30,8 +35,34 @@
       AND DEVICE_ID = #{deviceId}
   </delete>
 
-  <select id="selectTokensByMemberId" parameterType="long" resultType="string">
-    SELECT FCM_TOKEN FROM MEMBER_DEVICE WHERE MEMBER_ID = #{memberId}
+  <select id="selectActiveTokensByMemberId" parameterType="long" resultType="string">
+    SELECT DISTINCT FCM_TOKEN
+    FROM MEMBER_DEVICE
+    WHERE MEMBER_ID = #{memberId}
+      AND IS_ACTIVE = 1
+      AND FCM_TOKEN IS NOT NULL
   </select>
+
+  <update id="deactivateByToken" parameterType="string">
+    UPDATE MEMBER_DEVICE
+    SET IS_ACTIVE = 0,
+        UPDATED_AT = SYSTIMESTAMP
+    WHERE FCM_TOKEN = #{token}
+  </update>
+
+  <!-- 오래된/비활성 토큰 정리 -->
+  <delete id="deleteStale">
+    DELETE FROM MEMBER_DEVICE
+    WHERE IS_ACTIVE = 0
+    AND NVL(LAST_SUCCESS_AT, TO_TIMESTAMP('1970-01-01','YYYY-MM-DD')) &lt; SYSTIMESTAMP - INTERVAL '90' DAY
+    AND UPDATED_AT &lt; SYSTIMESTAMP - INTERVAL '60' DAY
+  </delete>
+
+  <update id="markSuccessByToken" parameterType="string">
+    UPDATE MEMBER_DEVICE
+    SET LAST_SUCCESS_AT = SYSTIMESTAMP,
+        UPDATED_AT      = SYSTIMESTAMP
+    WHERE FCM_TOKEN = #{token}
+  </update>
 
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentMapper.xml
@@ -33,6 +33,7 @@
     <id     property="orderId"     column="ORDER_ID"/>
     <result property="totalPrice"  column="TOTAL_PRICE"/>
     <result property="orderStatus" column="ORDER_STATUS"/>
+    <result property="orderSummary" column="ORDER_SUMMARY"/>
   </resultMap>
 
   <resultMap id="OrderItemRM" type="com.refit.app.domain.payment.dto.OrderItemRowDto">
@@ -90,7 +91,7 @@
 
   <!-- ORDER / ORDER_ITEM -->
   <select id="findOrderForUpdate" parameterType="string" resultMap="OrderRM">
-    SELECT ORDER_ID, TOTAL_PRICE, NVL(ORDER_STATUS,0) AS ORDER_STATUS
+    SELECT ORDER_ID, TOTAL_PRICE, NVL(ORDER_STATUS,0) AS ORDER_STATUS, ORDER_SUMMARY
     FROM ORDERS
     WHERE ORDER_CODE = #{orderCode}
       FOR UPDATE
@@ -138,7 +139,8 @@
       o.TOTAL_PRICE  AS totalPrice,
       o.ORDER_STATUS AS orderStatus,
       o.GOODS_AMOUNT AS goodsAmount,
-      o.DELIVERY_FEE AS deliveryFee
+      o.DELIVERY_FEE AS deliveryFee,
+      o.ORDER_SUMMARY AS orderSummary
     FROM ORDERS o
     WHERE o.ORDER_ID = #{orderId}
       FOR UPDATE

--- a/src/test/java/com/refit/app/domain/memberProduct/mapper/MemberProductMapperTest.java
+++ b/src/test/java/com/refit/app/domain/memberProduct/mapper/MemberProductMapperTest.java
@@ -80,8 +80,8 @@ class MemberProductMapperTest {
         assertThat(d.getBrandName()).isEqualTo("브랜드A");
         assertThat(d.getProductName()).isEqualTo("앰플A");
         assertThat(d.getRecommendedPeriod()).isEqualTo(90);
-        assertThat(d.getCategoryName()).isEqualTo("스킨케어");
-        // effectNames는 PRODUCT_EFFECT 집계를 타므로 "보습, 진정" 중 하나의 조합
+        assertThat(d.getCategoryId()).isEqualTo(100L);
+        // effects는 EFFECT_ID 리스트이므로 비어있지 않으면 OK
         assertThat(d.getEffects()).isNotNull();
         assertThat(d.getEffects()).isNotEmpty();
     }
@@ -98,7 +98,7 @@ class MemberProductMapperTest {
                 "브랜드X",
                 1,
                 100L,
-                List.of(1L, 2L)
+                List.of(1L, 2L) // EFFECT_ID: 1=보습, 2=진정
         );
         assertThat(id).isNotNull();
 
@@ -110,7 +110,8 @@ class MemberProductMapperTest {
         assertThat(d.getProductId()).isNull(); // 외부 상품은 product_id 없음
         assertThat(d.getBrandName()).isEqualTo("브랜드X");
         assertThat(d.getProductName()).isEqualTo("커스텀제품");
-        assertThat(d.getEffects()).containsExactlyInAnyOrder("보습", "진정");
+        // 효과는 ID 리스트를 검증
+        assertThat(d.getEffects()).containsExactlyInAnyOrder(1L, 2L);
     }
 
     @Test
@@ -226,6 +227,7 @@ class MemberProductMapperTest {
         assertThat(d.getBrandName()).isEqualTo("브X-수정");
         assertThat(d.getRecommendedPeriod()).isEqualTo(45);
         assertThat(d.getStartDate()).isEqualTo("2025-08-03");
-        assertThat(d.getEffects()).containsExactly("진정");
+        // 이름이 아니라 EFFECT_ID로 검증
+        assertThat(d.getEffects()).containsExactly(2L);
     }
 }

--- a/src/test/java/com/refit/app/domain/notification/ShedLockCoreTest.java
+++ b/src/test/java/com/refit/app/domain/notification/ShedLockCoreTest.java
@@ -1,0 +1,48 @@
+package com.refit.app.domain.notification;
+
+import net.javacrumbs.shedlock.core.DefaultLockingTaskExecutor;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ShedLockCoreTest {
+
+    @Autowired
+    LockProvider lockProvider;
+
+    @Test
+    void onlyOneThreadExecutesTask() throws Exception {
+        var executor = new DefaultLockingTaskExecutor(lockProvider);
+        var counter = new AtomicInteger(0);
+
+        Runnable tryRun = () -> executor.executeWithLock(
+                (Runnable) () -> {
+                    counter.incrementAndGet();
+                    try { Thread.sleep(1000); } catch (InterruptedException ignored) {}
+                },
+                new LockConfiguration(
+                        Instant.now(),
+                        "test-lock-core",          // 같은 락 이름
+                        Duration.ofSeconds(5),     // lockAtMostFor
+                        Duration.ofSeconds(3)      // lockAtLeastFor
+                )
+        );
+
+        Thread t1 = new Thread(tryRun);
+        Thread t2 = new Thread(tryRun);
+        t1.start(); t2.start();
+        t1.join(); t2.join();
+
+        // 두 쓰레드가 동시에 시도했지만 실제 실행은 1번만
+        assertThat(counter.get()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
- close #59

## 📝 요약(Summary)
- 소비기한 임박 시 사용자 알림 발송 기능
- 결제 상태 변화에 따른 푸시알림

- FCM 토큰 관리 개선
  - 전송 성공 시 LAST_SUCCESS_AT 갱신
  - 만료/무효 토큰은 IS_ACTIVE=0 으로 비활성화
  - 활성 토큰(IS_ACTIVE=1)만 조회하도록 쿼리 수정 및 DISTINCT 적용
  - DeviceService / PushService / NotificationTriggerService 역할 분리

- DB 스키마/제약 정리
  - (MEMBER_ID, DEVICE_ID)에 유니크 제약 추가
  - 중복 행 정리 및 인덱스 충돌 방지

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 테이블 추가 : SHEDLOCK
- 테이블 변경 : MEMBER_PRODUCT, MEMBER_DEVICE